### PR TITLE
Sonarcloud better persist to workspace

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ jobs:
           at: ~/
       - run:
           name: Analyze on Sonarcloud
-          command: gradle :sonarcloud
+          command: gradle sonarqube
 
 workflows:
   main:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,8 @@ jobs:
           key: squadmap-dependencies-{{ checksum "build.gradle" }}
       - attach_workspace:
           at: .
+      - run: ls -A1 ~/
+      - run: ls -A1 ~/squadmap
       - run: ls -A1 ~/squadmap/squadmap-frontend
       - run: ls -A1 ~/squadmap/squadmap-frontend/coverage
       - run: ls -A1 ~/squadmap/squadmap-frontend/coverage/squadmap-frontend

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
           key: squadmap-dependencies-{{ checksum "build.gradle" }}
       - attach_workspace:
           at: ./squadmap-frontend/coverage
-      - run: ls -A1 ./squadmap-frontend/coverage
+      - run: ls -A1 -r ./squadmap-frontend/coverage
       - run: gradle build
       - run:
           name: Analyze on SonarCloud

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,9 +40,9 @@ jobs:
             - "node_modules"
       - run: npm run test -- --no-watch --no-progress --browsers=ChromeHeadlessCI
       - persist_to_workspace:
-          root: ./squadmap/squadmap-frontend
+          root: ./coverage
           paths:
-            - coverage
+            - squadmap-frontend
 
 workflows:
   main:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,13 +16,10 @@ jobs:
           paths:
             - ~/.gradle
           key: squadmap-dependencies-{{ checksum "build.gradle" }}
-      - attach_workspace:
-          at: ~/
-      - run: ls -A1 ~/squadmap/squadmap-frontend
+      - persist_to_workspace:
+          root: ~/
+          paths: squadmap/sqaudmap-backend/build
       - run: gradle build
-      - run:
-          name: Analyze on SonarCloud
-          command: gradle :sonarqube
 
   frontend:
     docker:
@@ -43,6 +40,20 @@ jobs:
           root: ~/
           paths:
             - squadmap/squadmap-frontend/coverage
+
+  sonarcloud:
+    docker:
+      - image: circleci/openjdk:11-jdk
+    working_directory: ~/squadmap
+    steps:
+      - checkout:
+          path: ~/squadmap
+      - attach_workspace:
+          at: ~/
+      - run:
+          name: Analyze on Sonarcloud
+          command: gradle sonarcloud
+
 workflows:
   main:
     jobs:
@@ -50,5 +61,8 @@ workflows:
           context: SonarCloud
       - backend:
           context: SonarCloud
+      - sonarcloud:
+          context: SonarCloud
           requires:
             - frontend
+            - backend

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,7 @@ jobs:
       - attach_workspace:
           at: ~/squadmap/squadmap-frontend
       - run: ls -A1 ~/squadmap/squadmap-frontend
+      - run: ls -A1 ~/squadmap/squadmap-frontend/squadmap-frontend
       - run: gradle build
       - run:
           name: Analyze on SonarCloud
@@ -40,9 +41,9 @@ jobs:
             - "node_modules"
       - run: npm run test -- --no-watch --no-progress --browsers=ChromeHeadlessCI
       - persist_to_workspace:
-          root: ./coverage/squadmap-frontend
+          root: ./coverage
           paths:
-            -
+            - squadmap-frontend
 
 workflows:
   main:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,12 +17,11 @@ jobs:
             - ~/.gradle
           key: squadmap-dependencies-{{ checksum "build.gradle" }}
       - run: gradle build
-      - run: ls -A1 ~/sqaudmap/squadmap-backend
-      - run: ls -r -A1 ~/sqaudmap/squadmap-backend
+      - run: ls -r -A1 ~/squadmap/squadmap-backend
       - persist_to_workspace:
           root: ~/
           paths:
-            - squadmap/sqaudmap-backend/build
+            - squadmap/squadmap-backend/build
 
   frontend:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,6 @@ jobs:
       - attach_workspace:
           at: ~/squadmap
       - run: ls -A1 ~/squadmap/squadmap-frontend
-      - run: ls -A1 ~/squadmap/squadmap-frontend/squadmap-frontend
       - run: gradle build
       - run:
           name: Analyze on SonarCloud

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
           key: squadmap-dependencies-{{ checksum "build.gradle" }}
       - attach_workspace:
           at: ~/squadmap
-      - run: ls -A1 ~/squadmap/squadmap-frontend/coverage/squadmap-frontend
+      - run: ls -A1 ~/squadmap/squadmap-frontend
       - run: gradle build
       - run:
           name: Analyze on SonarCloud

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
             - ~/.gradle
           key: squadmap-dependencies-{{ checksum "build.gradle" }}
       - attach_workspace:
-          at: ~squadmap/squadmap-frontend/coverage
+          at: ~squadmap/squadmap-frontend
       - run: ls -A1 ~/squadmap/squadmap-frontend/coverage
       - run: gradle build
       - run:
@@ -40,9 +40,9 @@ jobs:
             - "node_modules"
       - run: npm run test -- --no-watch --no-progress --browsers=ChromeHeadlessCI
       - persist_to_workspace:
-          root: ~/
+          root: ./squadmap/squadmap-frontend
           paths:
-            - squadmap/squadmap-frontend/coverage
+            - coverage
 
 workflows:
   main:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
             - ~/.gradle
           key: squadmap-dependencies-{{ checksum "build.gradle" }}
       - attach_workspace:
-          at: ~/squadmap/squadmap-frontend
+          at: ~/squadmap
       - run: ls -A1 ~/squadmap/squadmap-frontend
       - run: ls -A1 ~/squadmap/squadmap-frontend/squadmap-frontend
       - run: gradle build
@@ -41,9 +41,9 @@ jobs:
             - "node_modules"
       - run: npm run test -- --no-watch --no-progress --browsers=ChromeHeadlessCI
       - persist_to_workspace:
-          root: ./coverage/squadmap-frontend
+          root: ./coverage
           paths:
-            - coverage
+            - squadmap-frontend
 
 workflows:
   main:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,10 +16,10 @@ jobs:
           paths:
             - ~/.gradle
           key: squadmap-dependencies-{{ checksum "build.gradle" }}
+      - run: gradle build
       - persist_to_workspace:
           root: ~/
           paths: squadmap/sqaudmap-backend/build
-      - run: gradle build
 
   frontend:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,8 +17,8 @@ jobs:
             - ~/.gradle
           key: squadmap-dependencies-{{ checksum "build.gradle" }}
       - attach_workspace:
-          at: ~squadmap/squadmap-frontend
-      - run: ls -A1 ~/squadmap/squadmap-frontend/coverage
+          at: ~/squadmap/squadmap-frontend
+      - run: ls -A1 ~/squadmap/squadmap-frontend
       - run: gradle build
       - run:
           name: Analyze on SonarCloud

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
             - ~/.gradle
           key: squadmap-dependencies-{{ checksum "build.gradle" }}
       - attach_workspace:
-          at: ~/squadmap
+          at: ~/
       - run: ls -A1 ~/squadmap/squadmap-frontend
       - run: gradle build
       - run:
@@ -40,10 +40,9 @@ jobs:
             - "node_modules"
       - run: npm run test -- --no-watch --no-progress --browsers=ChromeHeadlessCI
       - persist_to_workspace:
-          root: ./coverage
+          root: ~/
           paths:
-            - squadmap-frontend
-
+            - squadmap/squadmap-frontend/coverage
 workflows:
   main:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ jobs:
           at: ~/
       - run:
           name: Analyze on Sonarcloud
-          command: gradle sonarcloud
+          command: gradle :sonarcloud
 
 workflows:
   main:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,10 @@ jobs:
             - ~/.gradle
           key: squadmap-dependencies-{{ checksum "build.gradle" }}
       - attach_workspace:
-          at: ~/squadmap/squadmap-frontend/coverage/squadmap-frontend
+          at: .
+      - run: ls -A1 squadmap/squadmap-frontend
+      - run: ls -A1 squadmap/squadmap-frontend/coverage
+      - run: ls -A1 squadmap/squadmap-frontend/coverage/squadmap-frontend
       - run: gradle build
       - run:
           name: Analyze on SonarCloud

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,9 +40,9 @@ jobs:
             - "node_modules"
       - run: npm run test -- --no-watch --no-progress --browsers=ChromeHeadlessCI
       - persist_to_workspace:
-          root: ./coverage
+          root: ./coverage/squadmap-frontend
           paths:
-            - squadmap-frontend
+            -
 
 workflows:
   main:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ jobs:
       - persist_to_workspace:
           root: ~/
           paths:
-            - squadmap-frontend/coverage/squadmap-frontend
+            - squadmap/squadmap-frontend/coverage
 
 workflows:
   main:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,6 @@ jobs:
             - ~/.gradle
           key: squadmap-dependencies-{{ checksum "build.gradle" }}
       - run: gradle build
-      - run: ls -r -A1 ~/squadmap/squadmap-backend
       - persist_to_workspace:
           root: ~/
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,7 @@ jobs:
           key: squadmap-dependencies-{{ checksum "build.gradle" }}
       - attach_workspace:
           at: ./squadmap-frontend/coverage
+      - run: ls -A1 ./squadmap-frontend/coverage
       - run: gradle build
       - run:
           name: Analyze on SonarCloud

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
           key: squadmap-dependencies-{{ checksum "build.gradle" }}
       - attach_workspace:
           at: ~/squadmap
-      - run: ls -A1 ~/squadmap/squadmap-frontend
+      - run: ls -A1 ~/squadmap/squadmap-frontend/coverage/squadmap-frontend
       - run: gradle build
       - run:
           name: Analyze on SonarCloud

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,8 +18,6 @@ jobs:
           key: squadmap-dependencies-{{ checksum "build.gradle" }}
       - attach_workspace:
           at: ./squadmap-frontend/coverage
-      - run: ls -A1 ./squadmap-frontend
-      - run: ls -A1 ./squadmap-frontend
       - run: gradle build
       - run:
           name: Analyze on SonarCloud

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,9 +18,9 @@ jobs:
           key: squadmap-dependencies-{{ checksum "build.gradle" }}
       - attach_workspace:
           at: .
-      - run: ls -A1 squadmap/squadmap-frontend
-      - run: ls -A1 squadmap/squadmap-frontend/coverage
-      - run: ls -A1 squadmap/squadmap-frontend/coverage/squadmap-frontend
+      - run: ls -A1 ~/squadmap/squadmap-frontend
+      - run: ls -A1 ~/squadmap/squadmap-frontend/coverage
+      - run: ls -A1 ~/squadmap/squadmap-frontend/coverage/squadmap-frontend
       - run: gradle build
       - run:
           name: Analyze on SonarCloud

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,8 +17,8 @@ jobs:
             - ~/.gradle
           key: squadmap-dependencies-{{ checksum "build.gradle" }}
       - attach_workspace:
-          at: ./squadmap-frontend/coverage
-      - run: ls -A1 ./squadmap-frontend/coverage/coverage
+          at: ~squadmap/squadmap-frontend/coverage
+      - run: ls -A1 ~/squadmap/squadmap-frontend/coverage
       - run: gradle build
       - run:
           name: Analyze on SonarCloud
@@ -40,9 +40,9 @@ jobs:
             - "node_modules"
       - run: npm run test -- --no-watch --no-progress --browsers=ChromeHeadlessCI
       - persist_to_workspace:
-          root: .
+          root: ~/
           paths:
-            - coverage/squadmap-frontend
+            - squadmap-frontend/coverage/squadmap-frontend
 
 workflows:
   main:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
           key: squadmap-dependencies-{{ checksum "build.gradle" }}
       - attach_workspace:
           at: ./squadmap-frontend/coverage
-      - run: ls -A1 -r ./squadmap-frontend/coverage
+      - run: ls -A1 ./squadmap-frontend/coverage/coverage
       - run: gradle build
       - run:
           name: Analyze on SonarCloud

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,12 +17,9 @@ jobs:
             - ~/.gradle
           key: squadmap-dependencies-{{ checksum "build.gradle" }}
       - attach_workspace:
-          at: .
-      - run: ls -A1 ~/
-      - run: ls -A1 ~/squadmap
-      - run: ls -A1 ~/squadmap/squadmap-frontend
-      - run: ls -A1 ~/squadmap/squadmap-frontend/coverage
-      - run: ls -A1 ~/squadmap/squadmap-frontend/coverage/squadmap-frontend
+          at: ./squadmap-frontend/coverage
+      - run: ls -A1 ./squadmap-frontend
+      - run: ls -A1 ./squadmap-frontend
       - run: gradle build
       - run:
           name: Analyze on SonarCloud

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,9 +17,12 @@ jobs:
             - ~/.gradle
           key: squadmap-dependencies-{{ checksum "build.gradle" }}
       - run: gradle build
+      - run: ls -A1 ~/sqaudmap/squadmap-backend
+      - run: ls -r -A1 ~/sqaudmap/squadmap-backend
       - persist_to_workspace:
           root: ~/
-          paths: squadmap/sqaudmap-backend/build
+          paths:
+            - squadmap/sqaudmap-backend/build
 
   frontend:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,9 +41,9 @@ jobs:
             - "node_modules"
       - run: npm run test -- --no-watch --no-progress --browsers=ChromeHeadlessCI
       - persist_to_workspace:
-          root: ./coverage
+          root: ./coverage/squadmap-frontend
           paths:
-            - squadmap-frontend
+            - coverage
 
 workflows:
   main:

--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ project(":squadmap-frontend") {
             property "sonar.tests", "src"
             property "sonar.test.inclusions", "**/*.spec.ts"
             property "sonar.nodejs.executable", node.variant.nodeExec
-            property "sonar.typescript.lcov.reportPaths", "coverage/squadmap-frontend/coverage/squadmap-frontend/lcov.info"
+            property "sonar.typescript.lcov.reportPaths", "coverage/squadmap-frontend/lcov.info"
         }
     }
 }


### PR DESCRIPTION
Moved the sonarcloud analysis to its own task, so that frontend and backend can build at the same time.